### PR TITLE
Improve bloom filter performance, add approxNumberOfItems method

### DIFF
--- a/scala/data_structures/bloom_filter.scala
+++ b/scala/data_structures/bloom_filter.scala
@@ -1,66 +1,78 @@
 package data_structures
 
+import scala.util.hashing.MurmurHash3.stringHash
+import Math.{abs, ceil, log, pow, round}
+
 case class BloomFilter[A](
   nbOfItems: Int,
   falsePositiveProbability: Float,
   private val array: Array[Boolean],
-  private val hashFunctions: Array[String => Int]
+  private val numberOfHashFunctions: Int,
+  private val hashSeed: Int
 ) {
+
+  private val hashFunctions: Stream[String => Int] =
+    (1 to numberOfHashFunctions)
+      .toStream
+      .map(i => (str: String) => abs(stringHash(str, hashSeed + i)) % array.length)
 
   def +=(item: A): BloomFilter[A] = {
     val itemString = item.toString
-    val hashes = this.hashFunctions.map(_(itemString))
-    val updatedArray = hashes.foldLeft(this.array)((acc, hash) => acc.updated(hash, true))
-    BloomFilter(nbOfItems, falsePositiveProbability, updatedArray, hashFunctions)
+    val hashes = hashFunctions.map(_(itemString))
+    val updatedArray = hashes.foldLeft(array)((acc, hash) => acc.updated(hash, true))
+    this.copy(array=updatedArray)
   }
 
   def ++=(items: Seq[A]): BloomFilter[A] = items.foldLeft(this)(_ += _)
 
-  def contains(item: A): Boolean = {
+  def mayContain(item: A): Boolean = {
     val itemString = item.toString
-    this.hashFunctions.forall(fn => this.array(fn(itemString)))
+    hashFunctions.forall(fn => array(fn(itemString)))
+  }
+
+  def approxNumberOfItems(): Int = {
+    val setBits = array.filter(identity).length.toDouble
+    val totalBits = array.length.toDouble
+    round(
+      (-totalBits / numberOfHashFunctions.toDouble) * log((1D - (setBits / totalBits)))
+    ).toInt
   }
 }
 
 object BloomFilter {
 
-  import Math.{abs, ceil, log, pow, round}
-
   private def getArraySize(nbOfItems: Int, falsePositiveProbability: Float): Int =
     ceil(
-      abs(nbOfItems * log(falsePositiveProbability)) / log(1 / pow(log(2), 2))
+      abs(nbOfItems * log(falsePositiveProbability)).toDouble / log(1D / pow(log(2), 2).toDouble)
     ).toInt
 
   private def getNumberOfHashFunctions(nbOfItems: Int, arraySize: Int): Int =
     round(
-      (arraySize / nbOfItems) * log(2)
+      (arraySize.toDouble / nbOfItems.toDouble) * log(2)
     ).toInt
 
   def apply[A](nbOfItems: Int, falsePositiveProbability: Float): BloomFilter[A] = {
-    import scala.util.Random
-    import scala.util.hashing.MurmurHash3.stringHash
-
     val arraySize = getArraySize(nbOfItems, falsePositiveProbability)
-    val array = Array.ofDim[Boolean](arraySize)
-
-    val hashFunctions: Array[String => Int] =
-      Array.ofDim[String => Int](getNumberOfHashFunctions(nbOfItems, arraySize)).map(_ => {
-        val seed = Random.nextInt
-        (string: String) => abs(stringHash(string, seed)) % arraySize
-      })
-    BloomFilter(nbOfItems, falsePositiveProbability, array, hashFunctions)
+    BloomFilter(
+      nbOfItems=nbOfItems,
+      falsePositiveProbability=falsePositiveProbability,
+      array=Array.ofDim[Boolean](arraySize),
+      numberOfHashFunctions=getNumberOfHashFunctions(nbOfItems, arraySize),
+      hashSeed=scala.util.Random.nextInt
+    )
   }
 }
 
 object BloomFilterTest {
 
   def main(args: Array[String]): Unit = {
-    val empty = BloomFilter[Int](4000, 0.0000001f)
+    val empty = BloomFilter[Int](4, 0.1f)
     val withOne = empty += 4
     val withThree = withOne ++= Vector(5, 2910)
-    println(withThree contains 4)
-    println(withThree contains 5)
-    println(withThree contains 2910)
-    println(withThree contains 211)
+    println(withThree mayContain 4)
+    println(withThree mayContain 5)
+    println(withThree mayContain 2910)
+    println(withThree mayContain 211)
+    println(withThree.approxNumberOfItems)
   }
 }

--- a/scala/data_structures/bloom_filter.scala
+++ b/scala/data_structures/bloom_filter.scala
@@ -31,7 +31,7 @@ case class BloomFilter[A](
   }
 
   def approxNumberOfItems(): Int = {
-    val setBits = array.filter(identity).length.toDouble
+    val setBits = array.foldLeft(0)((acc, bit) => if (bit) acc + 1 else acc).toDouble
     val totalBits = array.length.toDouble
     round(
       (-totalBits / numberOfHashFunctions.toDouble) * log((1D - (setBits / totalBits)))


### PR DESCRIPTION
The most important change is that now, instead of using a distinct random number as seed for every single hash function, which consume entropy, is slow and forces us to hold all the hash functions in the bloom filter, only 1 random number is used and then all the seeds for all the hash functions are deterministically derived from that initial seed.
Also, the hash functions are no longer pre-generated and held in memory. Because their generation is now deterministic, we can generate them on the fly every time it is needed. This is achieve through the use of a Stream, a lazy Scala sequence.
Also, this PR adds a `approxNumberOfItems` method and renames `contains` to `mayContain`.